### PR TITLE
Update custom item register ID

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/reforges/Reforge.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/reforges/Reforge.kt
@@ -86,7 +86,7 @@ class Reforge(
 
         if (config.getBool("stone.enabled")) {
             CustomItem(
-                plugin.namespacedKeyFactory.create("stone_" + this.id),
+                plugin.namespacedKeyFactory.create("stone_" + this.id.key),
                 { test -> test.reforgeStone == this },
                 stone
             ).register()


### PR DESCRIPTION
This register ID will lead to reforge stone has the second : symbol, like: reforges:stone_reforges:bleed

This will lead to reforge stone will never be able to use in eco's Item lookup feature, this PR is fixing this problem.