### PR TITLE
feat: implement reforge application effects and events

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/ReforgesPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/ReforgesPlugin.kt
@@ -4,7 +4,10 @@ import com.willfp.eco.core.command.impl.PluginCommand
 import com.willfp.eco.core.display.DisplayModule
 import com.willfp.eco.core.items.Items
 import com.willfp.libreforge.conditions.Conditions
+import com.willfp.libreforge.effects.Effects
+import com.willfp.libreforge.filters.Filters
 import com.willfp.libreforge.loader.LibreforgePlugin
+import com.willfp.libreforge.triggers.Triggers
 import com.willfp.libreforge.loader.configs.ConfigCategory
 import com.willfp.libreforge.registerHolderProvider
 import com.willfp.reforges.commands.CommandReforge
@@ -13,6 +16,11 @@ import com.willfp.reforges.config.TargetYml
 import com.willfp.reforges.display.ReforgesDisplay
 import com.willfp.reforges.gui.ReforgeGUI
 import com.willfp.reforges.libreforge.ConditionHasReforge
+import com.willfp.reforges.libreforge.EffectApplyRandomReforge
+import com.willfp.reforges.libreforge.EffectApplyReforge
+import com.willfp.reforges.libreforge.EffectRemoveReforge
+import com.willfp.reforges.libreforge.FilterReforge
+import com.willfp.reforges.libreforge.TriggerReforgeItem
 import com.willfp.reforges.reforges.PriceMultipliers
 import com.willfp.reforges.reforges.ReforgeFinder
 import com.willfp.reforges.reforges.ReforgeStoneTag
@@ -49,6 +57,12 @@ class ReforgesPlugin : LibreforgePlugin() {
         Items.registerTag(ReforgeStoneTag)
 
         registerHolderProvider(ReforgeFinder.toHolderProvider())
+
+        Effects.register(EffectApplyReforge)
+        Effects.register(EffectApplyRandomReforge)
+        Effects.register(EffectRemoveReforge)
+        Triggers.register(TriggerReforgeItem)
+        Filters.register(FilterReforge)
     }
 
     override fun handleReload() {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/api/ReforgesAPI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/api/ReforgesAPI.kt
@@ -1,0 +1,34 @@
+@file:JvmName("ReforgesAPI")
+
+package com.willfp.reforges.api
+
+import com.willfp.eco.core.price.ConfiguredPrice
+import com.willfp.reforges.api.event.ReforgeApplyEvent
+import com.willfp.reforges.reforges.Reforge
+import com.willfp.reforges.util.reforge
+import com.willfp.reforges.util.timesReforged
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+
+/**
+ * Apply a reforge to an item, firing [ReforgeApplyEvent].
+ * Returns false if the event was cancelled; true if the reforge was applied.
+ */
+fun Player.applyReforge(
+    item: ItemStack,
+    reforge: Reforge,
+    price: ConfiguredPrice,
+    usedStone: Boolean = false
+): Boolean {
+    val event = ReforgeApplyEvent(this, item, reforge, price, usedStone)
+    Bukkit.getPluginManager().callEvent(event)
+
+    if (event.isCancelled) return false
+
+    event.price.pay(this)
+    item.reforge = event.reforge
+    item.timesReforged++
+    event.reforge.runOnReforgeEffects(this, item)
+    return true
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/api/event/ReforgeApplyEvent.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/api/event/ReforgeApplyEvent.kt
@@ -1,0 +1,34 @@
+package com.willfp.reforges.api.event
+
+import com.willfp.eco.core.price.ConfiguredPrice
+import com.willfp.reforges.reforges.Reforge
+import org.bukkit.entity.Player
+import org.bukkit.event.Cancellable
+import org.bukkit.event.HandlerList
+import org.bukkit.event.player.PlayerEvent
+import org.bukkit.inventory.ItemStack
+
+class ReforgeApplyEvent(
+    who: Player,
+    val item: ItemStack,
+    override var reforge: Reforge,
+    var price: ConfiguredPrice,
+    val usedStone: Boolean
+) : PlayerEvent(who), Cancellable, ReforgeEvent {
+    private var cancelled = false
+
+    override fun isCancelled() = cancelled
+
+    override fun setCancelled(cancelled: Boolean) {
+        this.cancelled = cancelled
+    }
+
+    override fun getHandlers(): HandlerList {
+        return handlerList
+    }
+
+    companion object {
+        @JvmStatic
+        val handlerList = HandlerList()
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/api/event/ReforgeEvent.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/api/event/ReforgeEvent.kt
@@ -1,0 +1,7 @@
+package com.willfp.reforges.api.event
+
+import com.willfp.reforges.reforges.Reforge
+
+interface ReforgeEvent {
+    val reforge: Reforge
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/api/extensions/DoubleExtensions.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/api/extensions/DoubleExtensions.kt
@@ -1,0 +1,3 @@
+package com.willfp.reforges.api.extensions
+
+fun Double.round(decimals: Int = 2): Double = "%.${decimals}f".format(this).toDouble()

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/commands/CommandApply.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/commands/CommandApply.kt
@@ -1,6 +1,9 @@
 package com.willfp.reforges.commands
 
 import com.willfp.eco.core.command.impl.Subcommand
+import com.willfp.eco.core.config.emptyConfig
+import com.willfp.eco.core.price.ConfiguredPrice
+import com.willfp.reforges.api.applyReforge
 import com.willfp.reforges.plugin
 import com.willfp.reforges.reforges.Reforges
 import com.willfp.reforges.util.reforge
@@ -30,8 +33,7 @@ object CommandApply : Subcommand(
 
         if (sender is Player) {
             val item = sender.inventory.itemInMainHand
-            item.reforge = reforge
-            reforge.runOnReforgeEffects(sender, item)
+            sender.applyReforge(item, reforge, ConfiguredPrice.createOrFree(emptyConfig()))
             sender.sendMessage(
                 plugin.langYml.getMessage("applied-reforge")
                     .replace("%reforge%", reforge.name)
@@ -50,9 +52,7 @@ object CommandApply : Subcommand(
             }
 
             val item = player.inventory.itemInMainHand
-
-            item.reforge = reforge
-            reforge.runOnReforgeEffects(player, item)
+            player.applyReforge(item, reforge, ConfiguredPrice.createOrFree(emptyConfig()))
             sender.sendMessage(
                 plugin.langYml.getMessage("applied-reforge")
                     .replace("%reforge%", reforge.name)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/gui/ReforgeGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/gui/ReforgeGUI.kt
@@ -23,6 +23,7 @@ import com.willfp.ecomponent.CaptiveItem
 import com.willfp.ecomponent.menuStateVar
 import com.willfp.ecomponent.setSlot
 import com.willfp.libreforge.LibreforgeSpigotPlugin
+import com.willfp.reforges.api.applyReforge
 import com.willfp.reforges.plugin
 import com.willfp.reforges.reforges.PriceMultipliers.reforgePriceMultiplier
 import com.willfp.reforges.reforges.Reforge
@@ -132,18 +133,13 @@ private class ActivatorSlot(
                 return@onLeftClick
             }
 
-            price.pay(player)
+            if (!player.applyReforge(item, reforge, price, usedStone)) return@onLeftClick
 
             player.sendMessage(plugin.langYml.getMessage("applied-reforge").replace("%reforge%", reforge.name))
 
-            item.timesReforged++
-            item.reforge = reforge
-
-            reforge.runOnReforgeEffects(player, item)
-
             if (usedStone) {
-                val stone = reforgeStone[player]
-                stone?.amount = stone?.amount?.minus(1) ?: 0
+                val stone = reforgeStone[player] ?: return@onLeftClick
+                stone.amount -= 1
                 PlayableSound.create(plugin.configYml.getSubsection("gui.stone-sound"))?.playTo(player)
             }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/EffectApplyRandomReforge.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/EffectApplyRandomReforge.kt
@@ -1,0 +1,33 @@
+package com.willfp.reforges.libreforge
+
+import com.willfp.eco.core.config.emptyConfig
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.core.price.ConfiguredPrice
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import com.willfp.reforges.api.applyReforge
+import com.willfp.reforges.reforges.ReforgeTargets
+import com.willfp.reforges.util.getRandomReforge
+import com.willfp.reforges.util.reforge
+
+object EffectApplyRandomReforge : Effect<NoCompileData>("apply_random_reforge") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.ITEM
+    )
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        val item = data.item ?: player.inventory.itemInMainHand
+
+        val targets = ReforgeTargets.getForItem(item)
+        if (targets.isEmpty()) return false
+
+        val reforge = targets.getRandomReforge(disallowed = listOfNotNull(item.reforge)) ?: return false
+
+        player.applyReforge(item, reforge, ConfiguredPrice.createOrFree(emptyConfig()))
+        return true
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/EffectApplyReforge.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/EffectApplyReforge.kt
@@ -1,0 +1,34 @@
+package com.willfp.reforges.libreforge
+
+import com.willfp.eco.core.config.emptyConfig
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.core.price.ConfiguredPrice
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.arguments
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import com.willfp.reforges.api.applyReforge
+import com.willfp.reforges.reforges.Reforges
+
+object EffectApplyReforge : Effect<NoCompileData>("apply_reforge") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.ITEM
+    )
+
+    override val arguments = arguments {
+        require("reforge", "You must specify the reforge to apply!")
+    }
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        val reforge = Reforges.getByKey(config.getString("reforge")) ?: return false
+        val item = data.item ?: player.inventory.itemInMainHand
+
+        if (!reforge.canBeAppliedTo(item)) return false
+
+        player.applyReforge(item, reforge, ConfiguredPrice.createOrFree(emptyConfig()))
+        return true
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/EffectRemoveReforge.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/EffectRemoveReforge.kt
@@ -1,0 +1,24 @@
+package com.willfp.reforges.libreforge
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import com.willfp.reforges.util.reforge
+
+object EffectRemoveReforge : Effect<NoCompileData>("remove_reforge") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER
+    )
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val player = data.player ?: return false
+        val item = player.inventory.itemInMainHand
+
+        if (item.type.isAir) return false
+
+        item.reforge = null
+        return true
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/FilterReforge.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/FilterReforge.kt
@@ -1,0 +1,19 @@
+package com.willfp.reforges.libreforge
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.filters.Filter
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.reforges.api.event.ReforgeEvent
+
+object FilterReforge : Filter<NoCompileData, Collection<String>>("reforge") {
+    override fun getValue(config: Config, data: TriggerData?, key: String): Collection<String> {
+        return config.getStrings(key)
+    }
+
+    override fun isMet(data: TriggerData, value: Collection<String>, compileData: NoCompileData): Boolean {
+        val event = data.event as? ReforgeEvent ?: return true
+
+        return value.any { it.equals(event.reforge.id.key, ignoreCase = true) }
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/TriggerReforgeItem.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/TriggerReforgeItem.kt
@@ -5,6 +5,7 @@ import com.willfp.libreforge.triggers.Trigger
 import com.willfp.libreforge.triggers.TriggerData
 import com.willfp.libreforge.triggers.TriggerParameter
 import com.willfp.reforges.api.event.ReforgeApplyEvent
+import com.willfp.reforges.api.extensions.round
 import org.bukkit.event.EventHandler
 
 object TriggerReforgeItem : Trigger("reforge_item") {
@@ -28,7 +29,7 @@ object TriggerReforgeItem : Trigger("reforge_item") {
                 item = event.item,
                 location = player.location,
                 text = event.reforge.name,
-                value = event.price.getValue(player),
+                value = event.price.getValue(player).round(2),
                 event = event
             )
         )

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/TriggerReforgeItem.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/reforges/libreforge/TriggerReforgeItem.kt
@@ -1,0 +1,36 @@
+package com.willfp.reforges.libreforge
+
+import com.willfp.libreforge.toDispatcher
+import com.willfp.libreforge.triggers.Trigger
+import com.willfp.libreforge.triggers.TriggerData
+import com.willfp.libreforge.triggers.TriggerParameter
+import com.willfp.reforges.api.event.ReforgeApplyEvent
+import org.bukkit.event.EventHandler
+
+object TriggerReforgeItem : Trigger("reforge_item") {
+    override val parameters = setOf(
+        TriggerParameter.PLAYER,
+        TriggerParameter.ITEM,
+        TriggerParameter.LOCATION,
+        TriggerParameter.TEXT,
+        TriggerParameter.VALUE,
+        TriggerParameter.EVENT
+    )
+
+    @EventHandler(ignoreCancelled = true)
+    fun handle(event: ReforgeApplyEvent) {
+        val player = event.player
+
+        this.dispatch(
+            player.toDispatcher(),
+            TriggerData(
+                player = player,
+                item = event.item,
+                location = player.location,
+                text = event.reforge.name,
+                value = event.price.getValue(player),
+                event = event
+            )
+        )
+    }
+}


### PR DESCRIPTION
Implemented API method and below new libreforge components:

- `apply_reforge` — applies a specific configured reforge to the trigger item (or main hand)
- `apply_random_reforge` — applies a random valid reforge to the trigger item (or main hand), excluding the current one
- `remove_reforge` — removes the reforge from the trigger item
- `reforge_item` (trigger) — fires when a reforge is applied; exposes %value% as the price paid and %text% as the reforge name
- `reforge` (filter) — filters reforge_item triggers by the reforge being applied