### PR TITLE
fix: Admonition format

### DIFF
--- a/documentation/reforges/how-to-make-a-custom-reforge.md
+++ b/documentation/reforges/how-to-make-a-custom-reforge.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: How to make a Reforge
 sidebar_position: 2
 ---
@@ -106,7 +106,7 @@ We support shaped and shapeless recipes. Check out [Recipes](https://plugins.aux
 :::
 
 ### The Reforge Effects Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The effects section is the core functionality of the reforge. You can configure effects, conditions, filters, mutators and triggers in this section to run whilst the reforge is active.
 


### PR DESCRIPTION
Fixes missing space between admonition type and title in documentation (e.g. `:::dangerEffects Section` → `:::danger Effects Section`).